### PR TITLE
#3: Use Valid Required-Workflow Trigger Event.

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -8,7 +8,7 @@ on:
       - development
 
 jobs:
-  create:
+  Create-Release-Tag:
     if: github.event.pull_request.merged
     runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,11 +1,15 @@
 name: Create Release Tag
 
 on:
-  push:
-    branches: [development]
-  
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - development
+
 jobs:
   create:
+    if: github.event.pull_request.merged
     runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Work for #3 to implement the suggestion in [this](https://github.com/atomic-works/github-required-workflows/issues/3#issuecomment-1483947287) comment. This also updates the name of the job to `Create-Release-Tag` to match the format of the other required workflow job, `Valid-Target-Branch`.